### PR TITLE
Update node samples following latest VS Code update

### DIFF
--- a/samples/BikeSharingApp/BikeSharingWeb/package.json
+++ b/samples/BikeSharingApp/BikeSharingWeb/package.json
@@ -21,7 +21,7 @@
     "export": "next export -o html",
     "start": "next build && NODE_ENV=production node server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "debug": "node --nolazy --inspect-brk=9229 server.js"
+    "debug": "node --nolazy server.js"
   },
   "repository": {
     "type": "git",

--- a/samples/BikeSharingApp/Bikes/package.json
+++ b/samples/BikeSharingApp/Bikes/package.json
@@ -14,6 +14,6 @@
     "nodemon": "^1.18.10"
   },
   "scripts": {
-    "debug": "node --nolazy --inspect-brk=9229 server.js"
+    "debug": "node --nolazy server.js"
   }
 }

--- a/samples/BikeSharingApp/Users/package.json
+++ b/samples/BikeSharingApp/Users/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
-    "debug": "node --nolazy --inspect-brk=9229 server.js"
+    "debug": "node --nolazy server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With the latest VS Code update, our breakpoints are not bound properly.
Please see: https://github.com/microsoft/vscode/issues/99526#issuecomment-657114179