### PR TITLE
Remove unused ItemGroup entries from Gateway csproj

### DIFF
--- a/samples/BikeSharingApp/Gateway/app.csproj
+++ b/samples/BikeSharingApp/Gateway/app.csproj
@@ -5,20 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Connected Services\" />
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Kubernetes.Tools.Targets" Version="1.1.0" />
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <WCFMetadata Include="Connected Services" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
There are a few extra unnecessary ItemGroup entries in the .csproj for the Gateway project that cause the VS solution explorer to append error icons on those particular items.