### PR TITLE
Use kubernetes environment variables

### DIFF
--- a/samples/todo-app/deployment.yaml
+++ b/samples/todo-app/deployment.yaml
@@ -102,11 +102,6 @@ spec:
       containers:
       - name: stats-api
         image: azdspublic/todo-app-stats-api
-        env:
-        - name: REDIS_HOST
-          value: stats-cache
-        - name: REDIS_PORT
-          value: "6379"
 ---
 apiVersion: v1
 kind: Service

--- a/samples/todo-app/stats-api/server.js
+++ b/samples/todo-app/stats-api/server.js
@@ -4,11 +4,11 @@ var redis = require('redis');
 var app = express();
 
 var cache = redis.createClient({
-    host: process.env.REDIS_HOST,
-    port: process.env.REDIS_PORT,
+    host: process.env.STATS_CACHE_SERVICE_HOST,
+    port: process.env.STATS_CACHE_SERVICE_PORT,
     tls: process.env.REDIS_SSL == "true" ? {
-        host: process.env.REDIS_HOST,
-        port: process.env.REDIS_PORT,
+        host: process.env.STATS_CACHE_SERVICE_HOST,
+        port: process.env.STATS_CACHE_SERVICE_PORT,
     } : undefined,
     password: process.env.REDIS_PASSWORD || undefined
 });


### PR DESCRIPTION
Updated the stats-api to use kubernetes service environment variables when connecting to the cache client which is exposed by stats-cache service.