### PR TITLE
Format samples/README.md for easier reading as raw markdown

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,5 +1,7 @@
 # Bridge to Kubernetes Samples
+
 These sample projects are used in Bridge to Kubernetes documentation to demonstrate product capabilities.
+
 1. **BikeSharingApp**: A large application implemented as multiple microservices written in various languages. This provides a good example of a complex application for a team developing large applications. [Visual Studio Quickstart](https://aka.ms/bridge-to-k8s-vs-quickstart) | [Visual Studio Code Quickstart](https://aka.ms/bridge-to-k8s-vscode-quickstart)
 1. **ToDo App**: This sample is an extended TODO application and is composed of six inter-related components. It is is a good example for illustrating how Bridge to Kubernetes can be used to develop a microservice application on any Kubernetes cluster. This sample has been adapted from code provided by [TodoMVC](http://todomvc.com).
 1. **Azure Voting App**: The default Azure Kubernetes Service (AKS) sample application.  A 2 service application (Python/Redis) that provides users an expedited quick-start.  https://github.com/Azure-Samples/azure-voting-app-redis ![AzureVoteGif](https://github.com/microsoft/mindaro/raw/master/assets/lpk-sample-azurevote.gif)


### PR DESCRIPTION
While I was going through this sample I found that this file was a little hard to read when opened without a markdown preview. I also noticed the root README was formatted differently and didn't have this problem.

This PR adds two lines to make it easier to read and in line with the root README.