### PR TITLE
reset ingress config and upgrade traefik v1.85.0 to latest match K8s …

### DIFF
--- a/bridge-quickstart.sh
+++ b/bridge-quickstart.sh
@@ -125,18 +125,18 @@ az aks get-credentials -g $RGNAME -n $AKSNAME
 
 # Use Helm to deploy a traefik ingress controller
 echo "helm repo add && helm repo update"
-$HELMDIR/helm repo add stable https://charts.helm.sh/stable
+$HELMDIR/helm repo add traefik https://helm.traefik.io/traefik
 $HELMDIR/helm repo update
 
 echo ""
 echo "helm install traefik ingress controller in $BIKENS $HELMARGS"
-$HELMDIR/helm install "$INGRESSNAME-$BIKENS" stable/traefik \
+$HELMDIR/helm install "$INGRESSNAME-$BIKENS" traefik/traefik \
    --namespace $BIKENS --create-namespace \
    --set kubernetes.ingressClass=traefik \
    --set fullnameOverride=$INGRESSNAME \
    --set rbac.enabled=true \
    --set kubernetes.ingressEndpoint.useDefaultPublishedService=true \
-   --version 1.85.0 $HELMARGS
+   --version 10.20.0 $HELMARGS
 
 echo ""
 echo "Waiting for BikeSharing ingress Public IP to be assigned..."

--- a/samples/BikeSharingApp/BikeSharingWeb/charts/bikesharingweb/templates/ingress.yaml
+++ b/samples/BikeSharingApp/BikeSharingWeb/charts/bikesharingweb/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "bikesharingweb.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/BikeSharingWeb/charts/bikesharingweb/templates/ingress.yaml
+++ b/samples/BikeSharingApp/BikeSharingWeb/charts/bikesharingweb/templates/ingress.yaml
@@ -38,5 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
+                  number: 80
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Bikes/charts/bikes/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Bikes/charts/bikes/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "bikes.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Bikes/charts/bikes/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Bikes/charts/bikes/templates/ingress.yaml
@@ -38,5 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
+                  number: 80
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Billing/charts/billing/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Billing/charts/billing/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "billing.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Billing/charts/billing/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Billing/charts/billing/templates/ingress.yaml
@@ -38,5 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
+                  number: 80
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Gateway/charts/gateway/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Gateway/charts/gateway/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "gateway.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Gateway/charts/gateway/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Gateway/charts/gateway/templates/ingress.yaml
@@ -38,5 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
+                  number: 80
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/PopulateDatabase/charts/populatedatabase/templates/ingress.yaml
+++ b/samples/BikeSharingApp/PopulateDatabase/charts/populatedatabase/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "populatedatabase.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/PopulateDatabase/charts/populatedatabase/templates/ingress.yaml
+++ b/samples/BikeSharingApp/PopulateDatabase/charts/populatedatabase/templates/ingress.yaml
@@ -38,5 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
+                  number: 80
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Reservation/charts/reservation/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Reservation/charts/reservation/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "reservation.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Reservation/charts/reservation/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Reservation/charts/reservation/templates/ingress.yaml
@@ -38,5 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
+                  number: 80
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/ReservationEngine/charts/reservationengine/templates/ingress.yaml
+++ b/samples/BikeSharingApp/ReservationEngine/charts/reservationengine/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "reservationengine.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/ReservationEngine/charts/reservationengine/templates/ingress.yaml
+++ b/samples/BikeSharingApp/ReservationEngine/charts/reservationengine/templates/ingress.yaml
@@ -38,5 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
+                  number: 80
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Users/charts/users/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Users/charts/users/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "users.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/samples/BikeSharingApp/Users/charts/users/templates/ingress.yaml
+++ b/samples/BikeSharingApp/Users/charts/users/templates/ingress.yaml
@@ -38,5 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
+                  number: 80
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22.

Migrate manifests and API clients to use the networking.k8s.io/v1 API version, available since v1.19.


- The backend serviceName field is renamed to service.name
- String backend servicePort fields are renamed to service.port.name
- pathType is now required for each specified path. Options are Prefix, Exact, and ImplementationSpecific. To match the undefined v1beta1 behavior, use ImplementationSpecific. 

For more detailed information, see the [Kubernetes deprecated API migration guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22)

upgrade traefik v1.85.0 to latest 
Detail: https://traefik.github.io/traefik-helm-chart/